### PR TITLE
Add browser storage.sync cache for saving chat history- fix #3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
-        "browser": true
+        "browser": true,
+        "webextensions": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "susi firefox extension",
     "fossasia",
     "susi ai",
-    "sui"
+    "susi"
   ],
   "author": "tstreamDOTh",
   "license": "ISC",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,11 @@
   "name": "SUSI Chatbot",
   "version": "1.0",
   "description": "Firefox extension for the SUSI Chatbot",
+  "applications": {
+      "gecko": {
+          "id": "tstream.h@outlook.com"
+      }
+  },
   "browser_action": {
     "default_popup": "chatbot.html",
     "default_icon" : {
@@ -22,6 +27,7 @@
   "permissions":[
     "http://*/*",
     "https://*/*",
-    "http://ajax.googleapis.com/ajax/libs/jquery/"
+    "http://ajax.googleapis.com/ajax/libs/jquery/",
+    "storage"
   ]
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -3,10 +3,58 @@ var messageFormElement = document.getElementById("messageForm");
 var inputMessageElement = document.getElementById("inputMessage");
 var messagesHistoryElement = document.getElementById("messagesHistory");
 var messageCount=0;
+var messagesHistory=[]; 
 messageFormElement.addEventListener("submit", function (event) {
 	event.preventDefault();
 	handleMessageInputSubmit();
 });
+
+document.addEventListener("DOMContentLoaded", restoreMessages);
+
+function restoreMessages(){
+	//Uncomment the line below and run the extension to clear the storage.
+	//browser.storage.sync.clear();
+	var buffer = browser.storage.sync.get(null);
+	buffer.then(function(res){
+		if(res["messagesHistory"]){
+			messagesHistory = res["messagesHistory"];
+			var currentTimeString=getCurrentTimeString();
+			for(var i = 0  ; i < messagesHistory.length ;  i++){
+				if(messagesHistory[i].type === "my"){
+					createMyMessageHistory(messagesHistory[i].message , messagesHistory[i].timeStamp , messagesHistory[i].msgId );
+				}
+				else{
+					createSusiMessageHistory(messagesHistory[i].message , messagesHistory[i].timeStamp , messagesHistory[i].msgId );
+				}
+			}
+		}
+	});
+}
+
+function createMyMessageHistory(message,timeString,msgId){
+	$(
+		"<div class='message-container message-container-my' id='myMessage"+msgId+"'> \
+    <div class='message-box message-my'> \
+    <div class='message-text'>"+message+"</div> \
+    <div class='message-time'>"+timeString+"</div> \
+    </div> \
+  </div>"
+	).appendTo(messagesHistoryElement);
+	messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
+}
+
+function createSusiMessageHistory(message,timeString,msgId_susi){
+	$(
+		"<div class='message-container message-container-susi' id='susiMessage"+msgId_susi+"'> \
+    <div class='message-box-susi message-susi'>\
+    <div class='message-text'>"+message+"</div> \
+    <div class='message-time'>"+timeString+"</div> \
+    </div> \
+  </div>"
+	).appendTo(messagesHistoryElement);
+	messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
+}
+
 
 function handleMessageInputSubmit(){
 	var message=inputMessageElement.value;
@@ -17,7 +65,9 @@ function handleMessageInputSubmit(){
 	}
 	else{
 		var currentTimeString=getCurrentTimeString();
-		var msgId=messageCount++;
+		var msgId=messagesHistory.length+1;
+		messagesHistory.push({"message" : message, "msgId" : msgId.toString(), "type" : "my", "timeStamp" : currentTimeString});
+		browser.storage.sync.set({"messagesHistory": messagesHistory});
 		createMyMessage(message,currentTimeString,msgId);
 	}
 
@@ -46,11 +96,11 @@ function getCurrentTimeString() {
 function createMyMessage(message,timeString,msgId){
 	$(
 		"<div class='message-container message-container-my' id='myMessage"+msgId+"'> \
-		<div class='message-box message-my'> \
-		<div class='message-text'>"+message+"</div> \
-		<div class='message-time'>"+timeString+"</div> \
-		</div> \
-	</div>"
+    <div class='message-box message-my'> \
+    <div class='message-text'>"+message+"</div> \
+    <div class='message-time'>"+timeString+"</div> \
+    </div> \
+  </div>"
 	).appendTo(messagesHistoryElement);
 	messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
 	fetchResponse(message,msgId);
@@ -60,10 +110,12 @@ function createMyMessage(message,timeString,msgId){
 function createSusiMessage(message,timeString,msgId_susi){
 	$("#susiMessage"+msgId_susi).html(
 		"<div class='message-box-susi message-susi'> \
-		<div class='message-text'>"+message+"</div> \
-		<div class='message-time'>"+timeString+"</div> \
-	</div>");
+    <div class='message-text'>"+message+"</div> \
+    <div class='message-time'>"+timeString+"</div> \
+  </div>").appendTo(messagesHistoryElement);
 	messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
+	messagesHistory.push({"message" : message, "msgId" : msgId_susi.toString(), "type" : "susi", "timeStamp" : timeString});
+	browser.storage.sync.set({"messagesHistory": messagesHistory});
 }
 
 function showLoading(show,msgId_susi){
@@ -71,10 +123,10 @@ function showLoading(show,msgId_susi){
 		// create loading with this msgId_susi
 		$(
 			"<div class='message-container message-container-susi' id='susiMessage"+msgId_susi+"'> \
-			<div class='message-box-susi message-susi'> \
-			<div class='message-text'><img src='images/loading.gif' class='loading' /></div> \
-			</div> \
-		</div>"
+      <div class='message-box-susi message-susi'> \
+      <div class='message-text'><img src='images/loading.gif' class='loading' /></div> \
+      </div> \
+    </div>"
 		).appendTo(messagesHistoryElement);
 		messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
 	}


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes issue #3 

#### Changes proposed in this pull request:

- Add browser.syn for implementing the cache.
- Now the messages are stored into browser data and reload when the popup is opened back.
- If the user is logged in the browser then the message history is synced.

