### PR TITLE
Add theme preferences - fixes #5

### DIFF
--- a/src/chatbot.html
+++ b/src/chatbot.html
@@ -12,10 +12,10 @@
 	<link rel="stylesheet" type="text/css" href="index.css">
 </head>
 <body>
-	<div class="container">
-		<section class="top-bar">
+	<div class="container" >
+		<div class="top-bar" id="nav" >
 			<img class="logo" src="images/susi_logo_white.png">
-		</section>
+		</div>
 		<section class="messages-history" id="messagesHistory">
 
 		</section>

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,26 @@ body{
 *{
   box-sizing: border-box;
 }
+
+.dark a:visited{
+  color: #D22486;
+}
+
+.dark a{
+  color: #009DFF;
+}
+
 .container{
   width: 320px;
   height: 450px;
+}
+
+.dark{
+  background-color: #000000 ;
+}
+
+.top-bar.dark{
+  background-color: rgb(25, 50, 76) ;
 }
 
 .top-bar{
@@ -29,6 +46,10 @@ body{
   height: 75%;
   overflow-y: scroll;
   overflow-x: hidden;
+}
+
+.messages-history.dark{
+  background: linear-gradient(135deg,#183850,#183850 25%,#192c3e 50%,#22254c 75%,#22254c);
 }
 .message-container-my{
   text-align: right;
@@ -60,6 +81,13 @@ body{
   border-radius: 14px;
 }
 
+.message-box.dark{
+  background: rgba(25,147,147,.2);
+  color: #0ad5c1;
+  border:none;
+
+}
+
 .message-box-susi{
   position: relative;
   text-align: left;
@@ -75,11 +103,19 @@ body{
   padding: 6px 10px;
   margin: 4px;
   border-radius: 8px;
-  margin-right: : auto;
+  margin-right: auto;
   margin-left: 12px;
   border: 1.1px solid #ffffff;
   border-radius: 14px;
 }
+
+.message-box-susi.dark{
+  background: rgba(25,147,147,.2);
+  color: #0ec879;
+  border:none;
+
+}
+
 
 
 .message-box:after{
@@ -96,6 +132,12 @@ body{
   -webkit-transform-origin: 0 0;
   -ms-transform-origin: 0 0;
   transform-origin: 0 0;
+}
+
+.message-box.dark:after{
+  border-color: #1a4256 #1a4257 #1a4256 #1a4256;
+  background: rgba(25,147,147,.2);
+
 }
 
 .message-box-susi:before{
@@ -115,6 +157,11 @@ body{
   transform-origin: 0 0;
 }
 
+.message-box-susi.dark:before{
+  border-color: #1a4256 #1a4257 #1a4256 #1a4256;
+  background: rgba(25,147,147,.2);
+  
+}
 
 .message-time{
   font-size: 10px;
@@ -197,7 +244,15 @@ body{
   height: 13%;
 }
 
+.input-area.dark{
+  background-color: rgb(25, 50, 76);
+  box-shadow: none;
+  height: 13%;
+}
+
+
 .input-area .input-message{
+  font-size: 14px;
   background-color: #ffffff;
   border:none;
   width: 80%;
@@ -208,6 +263,13 @@ body{
   margin-left:8px;
   outline: none;
 }
+
+.input-area .input-message.dark{
+  background-color: rgb(25, 50, 76);
+  color: #0ec879;
+
+}
+
 .input-area .input-button{
   background-color: inherit;
   padding: 5px;
@@ -220,9 +282,18 @@ body{
   transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 }
 .input-area .input-button .material-icons{
+  background-color: transparent;
   vertical-align: middle;
   color: #4285f4;
 }
+
+.input-area .input-button .material-icons.dark{
+  background-color: transparent;
+  vertical-align: middle;
+  color: #0ec879;
+}
+
+
 .input-area .input-button:hover{
   box-shadow: 0 3px 13px rgba(0,0,0,.3);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,11 @@
     "default_popup": "chatbot.html",
     "default_icon" : "icons/susi_icon.svg",
     "default_title" : "susi_ai"
+    
+  },
+
+  "options_ui": {
+    "page": "settings.html"
   },
 
   "icons": {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,9 +2,11 @@
 var messageFormElement = document.getElementById("messageForm");
 var inputMessageElement = document.getElementById("inputMessage");
 var messagesHistoryElement = document.getElementById("messagesHistory");
+var topBar = document.getElementById("nav");
 var messageCount=0;
 var messagesHistory=[];
 var enableSync=true;// set false for testing purpose
+var theme = "light"; //default
 
 messageFormElement.addEventListener("submit", function (event) {
 	event.preventDefault();
@@ -17,6 +19,7 @@ if(enableSync){
 function restoreMessages(){
 	var buffer = browser.storage.sync.get(null);
 	buffer.then(function(res){
+
 		if(res["messagesHistory"]){
 			messagesHistory = res["messagesHistory"];
 			for(var i = 0  ; i < messagesHistory.length ;  i++){
@@ -37,8 +40,54 @@ function restoreMessages(){
 			},100);
 
 		}
+		//set the theme
+		if(res["theme"]){
+			if(res["theme"]=="dark"){
+				theme = res["theme"];
+				$(".top-bar").addClass("dark");
+				$(".messages-history").addClass("dark");
+				$(".message-box").addClass("dark");
+				$(".message-box-susi").addClass("dark");
+				$(".input-area").addClass("dark");
+				$(".input-message").addClass("dark");
+				$(".material-icons").addClass("dark");
+
+			}
+			else{
+				theme = res["theme"];
+				$(".top-bar").removeClass("dark");
+				$(".messages-history").removeClass("dark");
+				$(".message-box").removeClass("dark");
+				$(".message-box-susi").removeClass("dark");
+				$(".input-area").removeClass("dark");
+				$(".input-message").removeClass("dark");
+				$(".material-icons").removeClass("dark");
+			}
+		}
 
 	});
+}
+
+function applyTheme(){
+	if(theme=="dark"){
+		$(".top-bar").addClass("dark");
+		$(".messages-history").addClass("dark");
+		$(".message-box").addClass("dark");
+		$(".message-box-susi").addClass("dark");
+		$(".input-area").addClass("dark");
+		$(".input-message").addClass("dark");
+		$(".material-icons").addClass("dark");
+
+	}
+	else{
+		$(".top-bar").removeClass("dark");
+		$(".messages-history").removeClass("dark");
+		$(".message-box").removeClass("dark");
+		$(".message-box-susi").removeClass("dark");
+		$(".input-area").removeClass("dark");
+		$(".input-message").removeClass("dark");
+		$(".material-icons").removeClass("dark");
+	}
 }
 
 function handleMessageInputSubmit(){
@@ -89,6 +138,7 @@ function createMyMessage(message,timeString,msgId){
 		browser.storage.sync.set({"messagesHistory": messagesHistory});
 	}
 	messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
+	applyTheme();
 	fetchResponse(message,msgId);
 }
 
@@ -222,6 +272,7 @@ function showLoading(show,msgId_susi){
     </div>"
 		).appendTo(messagesHistoryElement);
 		messagesHistoryElement.scrollTop = messagesHistoryElement.scrollHeight;
+		applyTheme();
 	}
 	else{
 		// hide loading in this msgId_susi
@@ -270,16 +321,19 @@ function composeResponse(data,currentTimeString,msgId_susi){
 		if(type==="answer"){
 			expression=action.expression;
 			createSusiMessageAnswer(expression,currentTimeString,msgId);
+			applyTheme();
 		}
 		else if(type==="rss"){
 			answers=data.answers[0].data;
 			count = action.count;
 			createSusiMessageRss(answers,count,currentTimeString,msgId);
+			applyTheme();
 		}
 		else if(type==="websearch"){
 			answers=data.answers[0].data;
 			count = action.count;
 			createSusiMessageRss(answers,count,currentTimeString,msgId);
+			applyTheme();
 		}
 		else if(type==="table"){
 			expression="table";
@@ -287,11 +341,13 @@ function composeResponse(data,currentTimeString,msgId_susi){
 			var columns = Object.keys(action.columns);
 			var columnsData = Object.values(action.columns);
 			createSusiMessageTable(tableData,columns,columnsData,currentTimeString,msgId);
+			applyTheme();
 		}
 		else{
 			// add support for duckduckgo search, maps, tables
 			expression="unable to fetch";
 			createSusiMessageAnswer(expression,currentTimeString,msgId);
+			applyTheme();
 		}
 	}
 }

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -1,0 +1,31 @@
+/* global $ */
+var settings = document.getElementById("settings");
+
+settings.addEventListener("submit", saveOptions);
+
+document.addEventListener("DOMContentLoaded", persistSettings);
+
+function persistSettings(){
+	var buffer = browser.storage.sync.get(null);
+	buffer.then(function(res){
+
+		if(res["theme"]){
+			if(res["theme"]=="dark"){
+				$("#theme").val("dark");
+			}
+			else{
+				$("#theme").val("light");
+			}
+		}
+
+	});
+}
+
+
+function saveOptions(e) {
+	e.preventDefault();
+	browser.storage.sync.set({
+		theme: document.querySelector("#theme").value
+	});
+  
+}

--- a/src/settings.css
+++ b/src/settings.css
@@ -1,0 +1,27 @@
+select {
+    width: 50%;
+    padding: 4px 4px;
+    border: none;
+    border-radius: 4px;
+    background-color: #f1f1f1;
+    font-size: 16px;
+}
+
+option{
+    padding: 16px 20px;
+    border: none;
+    border-radius: 0px;
+    background-color: #f1f1f1;
+}
+
+input[type=button], input[type=submit], input[type=reset] {
+    width: 30%;
+    border: none;
+    color: white;
+    padding: 16px 32px;
+    text-decoration: none;
+    margin: 4px 2px;
+    cursor: pointer;
+    font-size: 16px;
+    background-color: #4285f4;
+}

--- a/src/settings.html
+++ b/src/settings.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>SUSI Addon Settings</title>
+<link rel="stylesheet" type="text/css" href="settings.css">
+</head>
+<body>
+<h3>Settings</h3>
+<hr>
+<h4>Theme</h4>
+<form id="settings" >
+<select id="theme">
+  <option value="light">Light</option>
+  <option value="dark">Dark</option>
+</select>
+<br>
+<br>
+<br>
+<input type="submit" value="Save"/>
+</form>
+
+<script src="scripts/options.js"></script>
+<script src="scripts/jquery-3.2.1.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes issue #5

#### Changes proposed in this pull request:
- Added settings menu for the extension.
- Added option to choose a theme.
- Supports light & dark theme.
- Follows the original SUSI webchat colour palette.
- Persist settings

#### Screenshots for the change: 
![screen shot 2017-10-03 at 12 08 51 am](https://user-images.githubusercontent.com/11137394/31093353-1933cf6a-a7cf-11e7-9837-8352c3e6014b.png)
![screen shot 2017-10-03 at 12 03 49 am](https://user-images.githubusercontent.com/11137394/31093354-19393a5e-a7cf-11e7-9543-516063113220.png)
