### PR TITLE
Fix issue #31 - create keyboard shortcut for quicker access

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,7 @@
   "browser_action": {
     "default_popup": "chatbot.html",
     "default_icon" : "icons/susi_icon.svg",
-    "default_title" : "susi_ai"
+    "default_title" : "SUSI.AI (Alt+Shift+S)"
     
   },
 
@@ -42,5 +42,14 @@
     "http://ajax.googleapis.com/ajax/libs/jquery/",
     "storage",
     "https://cdn.jsdelivr.net/"
-  ]
+  ],
+
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+S"
+      }
+    }
+  }
+
 }


### PR DESCRIPTION

Fixes issue #31 

#### Changes proposed in this pull request:
* create keyboard shortcut Alt+Shift+S to open the add on popup.
* change tooltip to show the keyboard shortcut. 

#### Screenshots for the change:
when mouse cursor is placed over the icon, the new tooltip is displayed. 

![tooltip](https://user-images.githubusercontent.com/20047982/31121112-92b6531e-a854-11e7-929e-45bce41e4cbf.png)

