### PR TITLE
Fix Issue- #51 Fix the dark theme issue when the server is down.

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -430,6 +430,7 @@ function fetchResponse(query,msgId) {
 			};
 			var currentTimeString=getCurrentTimeString();
 			createSusiMessageAnswer(response.errorText, currentTimeString,msgId_susi);
+			applyTheme();
 		},
 		success: function (data) {
 			showLoading(false,msgId_susi);


### PR DESCRIPTION
Fixes issue #51 
#### Changes proposed in this pull request:
- The dark theme is now applied to the most recent message when the server is down.


#### Screenshots for the change: 
![fixed_dark](https://user-images.githubusercontent.com/24192122/31367216-67e675b2-ad93-11e7-84ba-9914b7ac7362.jpg)



