### PR TITLE
Fix #58 - make map zoomable only after clicking

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -195,6 +195,13 @@ function getCurrentTimeString() {
 
 function initiateMap(id,latitude,longitude,zoom){
 	var map = L.map(id).setView([latitude, longitude], zoom);
+	map.scrollWheelZoom.disable();
+	map.on("click",function(){
+		map.scrollWheelZoom.enable();
+	});
+	map.on("mouseout",function(){
+		map.scrollWheelZoom.disable();
+	});
 
 	L.tileLayer("http://{s}.tile.osm.org/{z}/{x}/{y}.png", {
 		attribution: ""


### PR DESCRIPTION
Fixes issue #58  

#### Changes proposed in this pull request:
* modify initiateMap function to make map zoomable only after clicking. 

