### PR TITLE
Add time formatting for retrieved messages - fixes #79

### DIFF
--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -112,9 +112,9 @@ function retrieveUserChatHistory(){
 				var queryResponsePair = response.cognitions[i];
 				var queryDate = new Date(Date.parse(queryResponsePair.query_date));
 				var answerDate = new Date(Date.parse(queryResponsePair.answer_date));
-				createMyMessageHistory(queryResponsePair.query, queryDate.toLocaleTimeString(), messagesHistory.length);
+				createMyMessageHistory(queryResponsePair.query, queryDate.toLocaleTimeString([], {hour: "2-digit", minute:"2-digit"}), messagesHistory.length);
 				if(queryResponsePair.answers.length>0){
-					createSusiMessageHistory(queryResponsePair, answerDate.toLocaleTimeString(), messagesHistory.length);
+					createSusiMessageHistory(queryResponsePair, answerDate.toLocaleTimeString([], {hour: "2-digit", minute:"2-digit"}), messagesHistory.length);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes issue #79 

#### Changes proposed in this pull request:
- Add options in toLocaleTimeString() function call in retrieveUserChatHistory() 

#### Screenshots for the change: 
![screen shot 2017-10-19 at 1 27 25 pm](https://user-images.githubusercontent.com/11137394/31760131-4941fee8-b4d1-11e7-9cd6-e88cdbdb8e2a.png)

