### PR TITLE
Fix #107 - hide scroll down button by default

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -19,7 +19,14 @@ messageFormElement.addEventListener("submit", function (event) {
 	event.preventDefault();
 	handleMessageInputSubmit();
 });
-
+function hideScrollButton(){
+	scrollIconElement.style.display="none";
+}
+function showScrollButton(){
+	scrollIconElement.style.display="block";
+}
+//hide scroll button by default
+hideScrollButton();
 // initialization based on cache status
 var buffer = browser.storage.sync.get(null);
 buffer.then(function(res){
@@ -76,11 +83,11 @@ function handleScroll(){
 	var end=messagesHistoryElement.scrollHeight - messagesHistoryElement.scrollTop === messagesHistoryElement.clientHeight;
 	if(end){
 		//hide icon
-		scrollIcon.style.display="none";
+		hideScrollButton();
 	}
 	else{
 		//show icon
-		scrollIcon.style.display="block";
+		showScrollButton();
 	}
 	// retrive history on scrolling
 	if(messagesHistoryElement.scrollTop == 0){


### PR DESCRIPTION
Fixes issue #107 

#### Changes proposed in this pull request:
- make different functions for hide and show scroll down button
- hide scroll down button initially


#### Screenshots for the change: 
![susi_firefox](https://user-images.githubusercontent.com/17807257/35474733-57683e5c-03b8-11e8-8d1b-e3f618104cf3.png)

