### PR TITLE
Using darker color for text in input-message class

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -361,6 +361,11 @@ body{
   margin-top: 8px;
   margin-left:8px;
   outline: none;
+  color: #000000;
+}
+
+.input-message::placeholder{
+  color: grey;
 }
 
 .input-area .input-message.dark{


### PR DESCRIPTION
Fixes #138 
#### Changes proposed in this pull request:
- I have used #000000 for text colour and grey for placeholder making them look distinct and readable

#### Screenshots for the change: 
![untitled](https://user-images.githubusercontent.com/19551058/47934733-31997480-defe-11e8-92af-fa6d0b50665d.png)