### PR TITLE
Sign up link now leads user directly to Sign Up form

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -21,7 +21,7 @@
 				<button type="submit" name="Login" id="loginbutton" value="Login">Login</button>
 				<br>
 				<br>
-				<a href="https://chat.susi.ai/">
+				<a href="https://accounts.susi.ai/signup">
 				New User? Visit our website to sign up for free.
 				</a>
 				<br>


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #149 
#### Changes proposed in this pull request:
- Sign up link now directs user to https://accounts.susi.ai/signup instead to https://chat.susi.ai . 



#### Screenshots for the change: 
GIF-
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/31539812/48313657-badb3600-e5e5-11e8-879f-d21e4abdadf3.gif)

