### PR TITLE
Proper eye in password field while logging

### DIFF
--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -354,7 +354,7 @@ function saveOptions(e) {
 
 		//check if user is logged in
 		if (accessToken != "") {
-			var topBarUrl = BASE_URL + "/aaa/changeUserSettings.json?key1=topBarColor&value1=" + selectedTopBarColor + 
+			var topBarUrl = BASE_URL + "/aaa/changeUserSettings.json?key1=topBarColor&value1=" + selectedTopBarColor +
 				"&access_token=" + accessToken + "&count=1";
 
 			// fire the api call to change settings value on server
@@ -623,7 +623,7 @@ passwordNew.addEventListener("keyup", function () {
 toggle.addEventListener("click", function () {
 	toggle.classList.toggle("fa-eye");
 	toggle.classList.toggle("fa-eye-slash");
-	if (toggle.classList.contains("fa-eye")) {
+	if (toggle.classList.contains("fa-eye-slash")) {
 		pass.type = "password";
 	}
 	else {

--- a/src/settings.html
+++ b/src/settings.html
@@ -15,7 +15,7 @@
 				<input type="email" id="username" placeholder="Email">
 				<br>
 				<input type="password" id="password" placeholder="Password">
-				<i class="fa fa-eye" id="toggle"></i>
+				<i class="fa fa-eye-slash" id="toggle"></i>
 				<br>
 				<br>
 				<button type="submit" name="Login" id="loginbutton" value="Login">Login</button>
@@ -73,7 +73,7 @@
 		<option value="dark">Dark</option>
 
 		<option disabled></option>
-		
+
 		<option value="red">Red</option>
 		<option value="blue">Blue</option>
 		<option value="black">Black</option>
@@ -86,7 +86,7 @@
 		<option value="dark">Dark</option>
 
 		<option disabled></option>
-		
+
 		<option value="red">Red</option>
 		<option value="blue">Blue</option>
 		<option value="black">Black</option>


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #152 

#### Changes proposed in this pull request:
When the eye is open then the password is shown vice-versa

#### Screenshots for the change: 
![eye firefox](https://user-images.githubusercontent.com/32234926/48326550-f4e91e00-e65f-11e8-9ec4-69dbd3a696ed.gif)




