### PR TITLE
Maximum characters limit for password field added 

### DIFF
--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -610,7 +610,7 @@ function urlDomain(data) {
 }
 
 passwordNew.addEventListener("keyup", function () {
-	if(passwordNew.value.length<6){
+	if(passwordNew.value.length<6 || passwordNew.value.length>64){
 		passwordLim.removeAttribute("hidden");
 		document.getElementById("changepasswordsubmit").setAttribute("disabled", "true");
 	}

--- a/src/settings.html
+++ b/src/settings.html
@@ -46,7 +46,7 @@
 					<input type="password" id="passwordnew" placeholder="New Password">
 				</div>
 				<div style="text-align: center">
-        	<small hidden id="passwordlim">Minimum 6 characters required</small>
+        	<small hidden id="passwordlim">Allowed password length is 6 to 64 characters</small>
         </div>
 				<div class="passwordnewconfirm">
 					<input type="password" id="passwordnewconfirm" placeholder="Confirm New Password">


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #164 

#### Changes proposed in this pull request:
- Since maximum password length for password is 64 characters is on server (confirm the fact from [here](https://github.com/fossasia/accounts.susi.ai/pull/582) ), warning should be shown when it exceeds the upper limit when a new password is added.
