### PR TITLE
Top bar color and message pan color values change when theme is changed to light/dark

### DIFF
--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -320,7 +320,15 @@ function saveOptions(e) {
 			theme: selectedtheme
 		});
 
-		if(selectedtheme !== "custom"){
+		if(selectedtheme === "light"){
+			document.querySelector("#top-bar-color").value = "light";
+			document.querySelector("#message-pane-color").value = "light";
+			topBarColorSelect.disabled = true;
+			messagePaneColorSelect.disabled = true;
+		}
+		else if(selectedtheme === "dark"){
+			document.querySelector("#top-bar-color").value = "dark";
+			document.querySelector("#message-pane-color").value = "dark";
 			topBarColorSelect.disabled = true;
 			messagePaneColorSelect.disabled = true;
 		}


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #171 

#### Changes proposed in this pull request:
The value of colors of top bar and message pane should change to light/dark with change in theme.

#### Screenshots for the change: 
GIF-
![ezgif com-video-to-gif 16](https://user-images.githubusercontent.com/31539812/48966196-7773c500-eff2-11e8-9e29-6a54b78f1050.gif)

