### PR TITLE
remove unnecessary text-decorations, color from dropdown items

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -484,7 +484,7 @@ body{
   background-color: #f9f9f9;
   min-width: 150px;
   box-shadow: 0px 8px 16px 0px rgb(0,0,0,0.2);
-  padding: 12px 0;
+  padding: 0px;
   z-index: 5;
   color: grey;
   list-style: none;
@@ -507,12 +507,14 @@ body{
   justify-content: space-between;
   margin: 5px 0;
   padding: 0 16px;
+  color: #887c7c;
 }
 .dropdown-content a li img {
   height: 30px;
 }
 .dropdown-content a{
-  color: #676767;
+  color: #887c7c;
+  text-decoration: none;
 }
 .dropdown-content a:hover{
   background-color: #e5e5e5;


### PR DESCRIPTION
Fixes #177 

#### Changes proposed in this pull request:
- Remove underline from dropdown items
- Colors of all the items should be alike
- Remove top and bottom padding from the list

#### Screenshots for the change: 

![image](https://user-images.githubusercontent.com/31389740/49216223-8bebff00-f3f0-11e8-8cf5-3ee3888e0e53.png)

