### PR TITLE
Eye is shifted completely inside password field

### DIFF
--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -77,7 +77,7 @@ button{
 .form-group {
   position: absolute;
   top: 19px;
-  left: 204px;
+  left: 190px;
 }
 
 hr{


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #180 

#### Changes proposed in this pull request:
Eye is completely inside password field now.

#### Screenshots for the change: 
Now:

![screenshot 2018-12-11 at 1 09 00 pm](https://user-images.githubusercontent.com/31539812/49785331-41e70f80-fd46-11e8-9b99-1c8214e12e9b.png)

Before:
![screenshot 2018-12-11 at 1 13 23 pm](https://user-images.githubusercontent.com/31539812/49785456-a1451f80-fd46-11e8-9615-82fe11b59378.png)

