### PR TITLE
make the eye icon consistent with all screen sizes

### DIFF
--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -78,9 +78,8 @@ button{
 }
 
 .form-group {
-  position: absolute;
   top: 19px;
-  left: 190px;
+  margin-left: -35px;
 }
 
 hr{


### PR DESCRIPTION
Fixes #186 
#### Changes proposed in this pull request:
- The eye icon for password should be consistent with all screen sizes.

#### Screenshots for the change: 
![susi1](https://user-images.githubusercontent.com/31389740/50047724-482c1180-00e1-11e9-91d8-68dd2e9f5ff1.gif)

