### PR TITLE
settings: fix eye overlapping with password

### DIFF
--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -50,6 +50,9 @@ input[type=text], input[type=password], input[type=email] {
     font-size: 16px;
     border-radius: 2px;
 }
+.password-form>input {
+    padding-right: 3rem;
+}
 
 button{
     text-align: center;


### PR DESCRIPTION
Fixes #188 

#### Changes proposed in this pull request:
- eye icon does not overlap with password

#### Screenshots for the change: 

![password_padd_firefoxbot](https://user-images.githubusercontent.com/31389740/50396354-9c915a00-078f-11e9-80c8-05519a62ffee.gif)
